### PR TITLE
refactor: フロントエンドコードの型安全性を向上

### DIFF
--- a/client/app/api/subgraph/route.ts
+++ b/client/app/api/subgraph/route.ts
@@ -134,8 +134,8 @@ export async function GET(request: Request) {
     });
     
     return NextResponse.json(merged);
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Subgraph API error:', error);
-    return NextResponse.json({ error: error?.message || String(error) }, { status: 500 });
+    return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
   }
 }

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -2,7 +2,15 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from 'react';
+import { RawProjectData, GraphNode } from '../src/types';
 
+// 型ガード関数
+function isRawProjectData(item: any): item is RawProjectData {
+  return typeof item === 'object' && 
+         (typeof item.project_id === 'string' || item.project_id === undefined) &&
+         (typeof item.agency_name === 'string' || item.agency_name === undefined) &&
+         (typeof item.ministry_name === 'string' || item.ministry_name === undefined);
+}
 
 import Fuse from 'fuse.js';
 // ノード座標キャッシュ
@@ -185,7 +193,7 @@ const ForceDirectedGraph: React.FC = () => {
     svg.selectAll('.node-group').select('circle')
       .attr('stroke', (d: any) => d.id === node.id ? '#e17055' : '#fff')
       .attr('stroke-width', (d: any) => d.id === node.id ? 6 : 1.5)
-      .attr('r', (d: any) => d.id === node.id ? 1.5 * ((d as Node).group ? (nodeSizeByGroup[(d as Node).group] ?? 8) : 8) : ((d as Node).group ? (nodeSizeByGroup[(d as Node).group] ?? 8) : 8))
+      .attr('r', (d: any) => d.id === node.id ? 1.5 * (d.group ? (nodeSizeByGroup[d.group] ?? 8) : 8) : (d.group ? (nodeSizeByGroup[d.group] ?? 8) : 8))
       .attr('opacity', (d: any) => d.id === node.id ? 1 : 0.15);
     svg.selectAll('.node-group').select('text')
       .attr('opacity', (d: any) => d.id === node.id ? 1 : 0.15);
@@ -196,7 +204,7 @@ const ForceDirectedGraph: React.FC = () => {
       svg.selectAll('.node-group').select('circle')
         .attr('stroke', '#fff')
         .attr('stroke-width', 1.5)
-        .attr('r', (d: any) => (d as Node).group ? (nodeSizeByGroup[(d as Node).group] ?? 8) : 8)
+        .attr('r', (d: any) => d.group ? (nodeSizeByGroup[d.group] ?? 8) : 8)
         .attr('opacity', 1);
       svg.selectAll('.node-group').select('text')
         .attr('opacity', 1);
@@ -221,8 +229,8 @@ const ForceDirectedGraph: React.FC = () => {
   const ministryNames = result.map(item => (item as any).ministry_name).filter(Boolean);
   const agencies = Array.from(new Set([...agencyNames, ...ministryNames])).filter(Boolean);
   setVisibleAgencies(agencies);
-      } catch (e: any) {
-        setError(e.message);
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : '不明なエラーが発生しました');
       } finally {
         setLoading(false);
       }
@@ -264,9 +272,9 @@ const ForceDirectedGraph: React.FC = () => {
       .scaleExtent([minZoom, maxZoom])
       .on('zoom', zoomed);
     zoomRef.current = zoom;
-  svg.call(zoom as any);
+  (svg as any).call(zoom);
   // 初期位置リセット
-  svg.call((zoom as any).transform, d3.zoomIdentity.translate(0, 0).scale(initialZoom));
+  (svg as any).call(zoom.transform, d3.zoomIdentity.translate(0, 0).scale(initialZoom));
     const tooltip = d3.select('body').append('div')
       .attr('class', 'tooltip')
       .style('opacity', 0)
@@ -325,18 +333,20 @@ const ForceDirectedGraph: React.FC = () => {
 
     // ノード生成
   data.forEach(item => {
-    let topLevel = (item as any)['agency_name'];
+    if (!isRawProjectData(item)) return;
+    const projectData = item;
+    let topLevel = projectData.agency_name;
     let topLevelKey = 'agency_name';
     if (!topLevel || topLevel === '' || topLevel === null || topLevel === undefined) {
-      topLevel = (item as any)['ministry_name'];
+      topLevel = projectData.ministry_name;
       topLevelKey = 'ministry_name';
     }
     // 表示対象の省庁のみ描画
     if (!visibleAgencies.includes(topLevel)) return;
-    const restHierarchy = hierarchyNames.map(key => (item as any)[key]).filter(Boolean);
-    const restHierarchyYomi = hierarchyNames.map(key => (item as any)[key + '_yomi']).filter(Boolean);
+    const restHierarchy = hierarchyNames.map(key => projectData[key as keyof RawProjectData]).filter(Boolean);
+    const restHierarchyYomi = hierarchyNames.map(key => projectData[(key + '_yomi') as keyof RawProjectData]).filter(Boolean);
     const hierarchy = [topLevel, ...restHierarchy].filter(Boolean);
-    const hierarchyYomi = [(item as any)[topLevelKey + '_yomi'], ...restHierarchyYomi].filter(Boolean);
+    const hierarchyYomi = [projectData[(topLevelKey + '_yomi') as keyof RawProjectData], ...restHierarchyYomi].filter(Boolean);
     let parentNodeId: string | null = null;
     let nodePath: string[] = [];
     let nodePathYomi: string[] = [];
@@ -344,8 +354,8 @@ const ForceDirectedGraph: React.FC = () => {
     const currentBudget = Number(item.initial_budget_total) || 0;
 
     hierarchy.forEach((name, index) => {
-      nodePath.push(name);
-      nodePathYomi.push(hierarchyYomi[index] || '');
+      nodePath.push(String(name));
+      nodePathYomi.push(String(hierarchyYomi[index] || ''));
       const nodeId = nodePath.join('→');
       const nodeYomi = nodePathYomi.join('→');
       const groupName = index === 0 ? topLevelKey : hierarchyNames[index - 1] || 'unknown';
@@ -370,7 +380,7 @@ const ForceDirectedGraph: React.FC = () => {
         }
         const newNode: Node = {
           id: nodeId,
-          name: name,
+          name: String(name),
           yomi: nodeYomi,
           group: groupName,
           value: 0, // Initialize to 0, will be aggregated
@@ -551,7 +561,7 @@ const ForceDirectedGraph: React.FC = () => {
   // 省庁名テキストが円からはみ出さないようピクセル幅で省略
   function getTextWidth(text: string, fontSize: number, fontFamily = 'Arial, sans-serif'): number {
     if (!text) return 0;
-  const canvas = ((getTextWidth as any) as any)._canvas || (((getTextWidth as any) as any)._canvas = document.createElement('canvas'));
+  const canvas = (getTextWidth as any)._canvas || ((getTextWidth as any)._canvas = document.createElement('canvas'));
     const ctx = canvas.getContext('2d');
     if (!ctx) return 0;
     ctx.font = `${fontSize}px ${fontFamily}`;
@@ -966,7 +976,7 @@ const ForceDirectedGraph: React.FC = () => {
         minWidth: 120
       }}>
         <div style={{ fontWeight: 'bold', marginBottom: 4, fontSize: isMobile ? 13 : 14 }}>省庁表示切替</div>
-        {Array.from(new Set(data.map(item => (item as any).agency_name).filter(Boolean))).map(agency => (
+        {Array.from(new Set(data.map(item => isRawProjectData(item) ? item.agency_name : undefined).filter((name): name is string => Boolean(name)))).map(agency => (
           <label key={agency} style={{ display: 'block', marginBottom: 2, fontSize: isMobile ? 13 : 14 }}>
             <input
               type="checkbox"

--- a/client/app/subgraph/page.tsx
+++ b/client/app/subgraph/page.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import React, { Suspense, useEffect, useRef, useState } from "react";
+import { RawProjectData, SpendingItem } from '../../src/types';
 import Fuse from 'fuse.js';
+
+// 型ガード関数
+function isRawProjectData(item: any): item is RawProjectData {
+  return typeof item === 'object' && 
+         (typeof item.project_id === 'string' || item.project_id === undefined) &&
+         (typeof item.agency_name === 'string' || item.agency_name === undefined) &&
+         (typeof item.ministry_name === 'string' || item.ministry_name === undefined);
+}
 // d3は既にimport済み
 // メイングラフと同じカラーマップ関数を利用
 import * as d3 from "d3";
@@ -49,7 +58,7 @@ function SubgraphContent() {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const zoomRef = useRef<d3.ZoomBehavior<Element, unknown> | null>(null);
   const [zoomTransform, setZoomTransform] = useState<d3.ZoomTransform | null>(null);
-  const [data, setData] = useState<any[]>([]);
+  const [data, setData] = useState<RawProjectData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [focusedNode, setFocusedNode] = useState<any | null>(null);
@@ -99,8 +108,8 @@ function SubgraphContent() {
         const merged = await response.json();
         setData(merged);
         console.log(`[データ取得] 件数: ${Array.isArray(merged) ? merged.length : (merged?.length ?? '不明')}`);
-      } catch (e: any) {
-        setError(e.message);
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : 'エラーが発生しました');
       } finally {
         setLoading(false);
       }
@@ -867,7 +876,7 @@ function SubgraphContent() {
               <strong>支払先企業一覧:</strong>
               <ul style={{ margin: '6px 0 0 0', padding: 0, listStyle: 'none', maxHeight: isMobile ? 150 : 120, overflowY: 'auto', fontSize: isMobile ? 13 : 14 }}>
                 {(focusedNode.spending_list && focusedNode.spending_list.length > 0) ? (
-                  focusedNode.spending_list.map((sp: any, idx: number) => (
+                  focusedNode.spending_list.map((sp: SpendingItem, idx: number) => (
                     <li key={idx} style={{ borderBottom: '1px solid #eee', padding: '2px 0' }}>
                       {sp.recipient_name || '(名称不明)'}
                       {sp.corporate_number ? `（法人番号: ${sp.corporate_number}）` : ''}

--- a/client/src/app/colorMap.ts
+++ b/client/src/app/colorMap.ts
@@ -1,19 +1,22 @@
 import * as d3 from 'd3';
+import { RawProjectData } from '../types';
 
 /**
  * データ配列からtopLevel（agency_nameまたはministry_name）ごとに色を割り当てるマップを生成
  * @param data APIから取得した全データ
  * @returns topLevel名→色のマップ
  */
-export function getColorMap(data: any[]): Record<string, string> {
+export function getColorMap(data: RawProjectData[]): Record<string, string> {
   // topLevel名のリストを抽出
   const topLevels = Array.from(new Set(
-    data.map(item => item.agency_name || item.ministry_name).filter(Boolean)
+    data
+      .map(item => item.agency_name || item.ministry_name)
+      .filter((name): name is string => Boolean(name))
   ));
   // d3.schemeTableau10の色を順に割り当て
   const colorScale = d3.scaleOrdinal<string, string>(d3.schemeTableau10);
   const colorMap: Record<string, string> = {};
-  topLevels.forEach((name, i) => {
+  topLevels.forEach((name) => {
     colorMap[name] = colorScale(name);
   });
   return colorMap;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,0 +1,106 @@
+// データベースから取得される生データの型定義
+export interface RawProjectData {
+  project_id?: string;
+  budget_year?: number;
+  project_year?: number;
+  organization_id?: string;
+  initial_budget_total?: number;
+  adjustment_total?: number;
+  carryover_from_previous_total?: number;
+  contingency_total?: number;
+  agency_name?: string;
+  ministry_name?: string;
+  agency_name_yomi?: string;
+  ministry_name_yomi?: string;
+  bureau_agency?: string;
+  bureau_agency_yomi?: string;
+  department?: string;
+  department_yomi?: string;
+  division?: string;
+  division_yomi?: string;
+  office?: string;
+  office_yomi?: string;
+  section?: string;
+  section_yomi?: string;
+  group?: string;
+  group_yomi?: string;
+  team?: string;
+  team_yomi?: string;
+  project_name?: string;
+  project_name_yomi?: string;
+  review_sheet_url?: string;
+  spending_list?: SpendingItem[];
+  initial_budget?: number;
+  // インデックスシグネチャを追加
+  [key: string]: any;
+}
+
+// ノードの型定義（グラフ表示用）
+export interface GraphNode {
+  id: string;
+  name: string;
+  group: string;
+  topLevel: string;
+  spending_list?: SpendingItem[];
+  x?: number;
+  y?: number;
+  fx?: number | null;
+  fy?: number | null;
+}
+
+// リンクの型定義（グラフ表示用）
+export interface GraphLink {
+  source: string | GraphNode;
+  target: string | GraphNode;
+  value: number;
+}
+
+// 支出項目の型定義
+export interface SpendingItem {
+  initial_budget_total?: number;
+  adjustment_total?: number;
+  carryover_from_previous_total?: number;
+  contingency_total?: number;
+  recipient_name?: string;
+  corporate_number?: string;
+  amount?: number;
+  block_name?: string;
+}
+
+// D3のイベント型定義
+export interface D3DragEvent {
+  x: number;
+  y: number;
+  dx: number;
+  dy: number;
+  subject: Node;
+}
+
+// APIレスポンスの型定義
+export interface ApiResponse<T> {
+  data: T[];
+  error?: string;
+}
+
+// ズーム変換の型定義（D3用）
+export interface ZoomTransform {
+  x: number;
+  y: number;
+  k: number;
+}
+
+// 検索結果の型定義
+export interface SearchResult {
+  item: Node;
+  refIndex: number;
+}
+
+// Kuromoji トークナイザーの型定義
+export interface KuromojiToken {
+  surface_form: string;
+  reading?: string;
+}
+
+export interface KuromojiTokenizer {
+  tokenize(text: string): KuromojiToken[];
+}


### PR DESCRIPTION
- any型を適切な型定義に置き換え
- 型ガード関数を実装してランタイム型チェックを追加
- 新しい型定義ファイル(src/types/index.ts)を作成
  - RawProjectData: APIレスポンスデータの型定義
  - GraphNode: グラフ表示用ノードの型定義
  - SpendingItem: 支出項目の型定義
- D3ライブラリ関連の型アサーションを修正
- エラーハンドリングでunknown型を使用し適切な型ガードを実装
- 文字列型変換を明示的に行いTypeScriptエラーを解消

🤖 Generated with [Claude Code](https://claude.ai/code)